### PR TITLE
AppOpsDetails: Check app permissions safely

### DIFF
--- a/src/com/android/settings/applications/AppOpsDetails.java
+++ b/src/com/android/settings/applications/AppOpsDetails.java
@@ -182,7 +182,7 @@ public class AppOpsDetails extends InstrumentedFragment {
                 sw.setVisibility(View.GONE);
 
                 final int switchOp = AppOpsManager.opToSwitch(firstOp.getOp());
-                int mode = mAppOps.checkOp(switchOp, entry.getPackageOps().getUid(),
+                int mode = mAppOps.checkOpNoThrow(switchOp, entry.getPackageOps().getUid(),
                         entry.getPackageOps().getPackageName());
                 sp.setSelection(modeToPosition(mode));
                 sp.setOnItemSelectedListener(new Spinner.OnItemSelectedListener() {
@@ -205,7 +205,7 @@ public class AppOpsDetails extends InstrumentedFragment {
                     }
                 });
 
-                sw.setChecked(mAppOps.checkOp(switchOp, entry.getPackageOps()
+                sw.setChecked(mAppOps.checkOpNoThrow(switchOp, entry.getPackageOps()
                         .getUid(), entry.getPackageOps().getPackageName()) == AppOpsManager.MODE_ALLOWED);
                 sw.setOnCheckedChangeListener(new Switch.OnCheckedChangeListener() {
                     public void onCheckedChanged(CompoundButton buttonView,


### PR DESCRIPTION
checkOp() throws a SecurityException when the application is not
allowed to perform the given operation. Use  checkOpNoThrow() so
that no exception is thrown. If the operation is not permitted,
AppOpsManager.MODE_ERRORED will be returned and AppOpsDetails will
treat it as MODE_IGNORED (i.e. don't allow).

BUGBASH-52

Change-Id: Ic3177a24ae52438594e65cd19e29a86c1ee299e8